### PR TITLE
feat: register custom servers + semver protocol versioning

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bombermp/client",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -598,7 +598,7 @@ async function boot(): Promise<void> {
     const match = servers.find((s) => s.slug === slugFromUrl);
     if (match) {
       const status = await pingServer(match);
-      if (status.online) {
+      if (status.online && status.versionCompatible) {
         switchToServer(match);
         const hashRoomId = getRoomIdFromHash();
         const storedName = getStoredDisplayName();

--- a/apps/client/src/socket/client.ts
+++ b/apps/client/src/socket/client.ts
@@ -1,5 +1,6 @@
 import { io, type Socket } from 'socket.io-client';
 import type { ClientToServerEvents, ServerToClientEvents } from '@bombermp/shared';
+import { GAME_VERSION } from '@bombermp/shared';
 
 // ─── Player Identity ──────────────────────────────────────────────────────────
 
@@ -51,7 +52,7 @@ export function connectToServer(url: string): AppSocket {
     autoConnect: false,
     withCredentials: true,
     transports: ['websocket', 'polling'],
-    auth: { playerId: getOrCreatePlayerId() },
+    auth: { playerId: getOrCreatePlayerId(), clientVersion: GAME_VERSION },
     reconnection: true,
     reconnectionAttempts: 5,
     reconnectionDelay: 1000,

--- a/apps/client/src/socket/servers.ts
+++ b/apps/client/src/socket/servers.ts
@@ -1,62 +1,159 @@
+import { GAME_VERSION, isMajorCompatible } from '@bombermp/shared';
 import { assetPath } from '../assets/registry.js';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 export interface ServerInfo {
-  slug: string;
-  name: string;
-  url:  string;
+  slug:        string;
+  name:        string;
+  url:         string;
+  /** Marked true for entries the user added themselves (stored in localStorage). */
+  isCustom?:   boolean;
 }
 
 export interface ServerStatus {
-  info:      ServerInfo;
-  online:    boolean;
-  players:   number;
-  latencyMs: number;
+  info:                ServerInfo;
+  online:              boolean;
+  players:             number;
+  latencyMs:           number;
+  /** Server version reported by /health, if any. */
+  serverVersion:       string | null;
+  /** True when client and server agree on major version. */
+  versionCompatible:   boolean;
 }
 
-// ─── Fetch server list ───────────────────────────────────────────────────────
+// ─── Built-in server list ────────────────────────────────────────────────────
 
 const WS_FALLBACK = (import.meta.env['VITE_WS_URL'] as string | undefined) ?? 'http://localhost:3001';
 
-export async function fetchServerList(): Promise<ServerInfo[]> {
+async function fetchBuiltInServers(): Promise<ServerInfo[]> {
   try {
     const res = await fetch(assetPath('/servers.json'));
     const list: ServerInfo[] = await res.json();
     if (Array.isArray(list) && list.length > 0) return list;
   } catch { /* fall through */ }
 
-  // Fallback: single server from env
   return [{ slug: 'default', name: 'Default', url: WS_FALLBACK }];
 }
 
-// ─── Ping a single server ────────────────────────────────────────────────────
+// ─── Custom servers (localStorage) ───────────────────────────────────────────
+
+const CUSTOM_SERVERS_KEY = 'bombermp_custom_servers';
+
+export function loadCustomServers(): ServerInfo[] {
+  try {
+    const raw = localStorage.getItem(CUSTOM_SERVERS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((s): s is ServerInfo =>
+        s && typeof s.slug === 'string' && typeof s.name === 'string' && typeof s.url === 'string')
+      .map((s) => ({ ...s, isCustom: true }));
+  } catch {
+    return [];
+  }
+}
+
+function saveCustomServers(servers: ServerInfo[]): void {
+  localStorage.setItem(CUSTOM_SERVERS_KEY, JSON.stringify(servers));
+}
+
+export function addCustomServer(server: Omit<ServerInfo, 'isCustom'>): void {
+  const existing = loadCustomServers();
+  const filtered = existing.filter((s) => s.slug !== server.slug);
+  filtered.push({ ...server, isCustom: true });
+  saveCustomServers(filtered);
+}
+
+export function removeCustomServer(slug: string): void {
+  const existing = loadCustomServers();
+  saveCustomServers(existing.filter((s) => s.slug !== slug));
+}
+
+/** Generate a stable slug from a URL — used as the localStorage key. */
+export function customSlugFromUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    const base = `custom-${u.host.replace(/[^a-z0-9]/gi, '-')}`;
+    return base.toLowerCase();
+  } catch {
+    return `custom-${Date.now()}`;
+  }
+}
+
+// ─── Combined server list ────────────────────────────────────────────────────
+
+/** Returns built-in servers merged with user-registered custom servers. */
+export async function fetchServerList(): Promise<ServerInfo[]> {
+  const builtIn = await fetchBuiltInServers();
+  const custom = loadCustomServers();
+  // Custom servers take precedence on slug collision (rare).
+  const bySlug = new Map<string, ServerInfo>();
+  for (const s of builtIn) bySlug.set(s.slug, s);
+  for (const s of custom)  bySlug.set(s.slug, s);
+  return [...bySlug.values()];
+}
+
+// ─── Health probe ────────────────────────────────────────────────────────────
 
 const PING_TIMEOUT_MS = 3000;
 
-export async function pingServer(server: ServerInfo): Promise<ServerStatus> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), PING_TIMEOUT_MS);
+interface HealthResponse {
+  status?:  string;
+  version?: string;
+  players?: number;
+}
 
+/**
+ * Fetches `/health` from a server URL and returns the parsed body + RTT.
+ * Throws on network error / timeout.
+ */
+export async function probeServer(url: string, timeoutMs = PING_TIMEOUT_MS): Promise<{
+  body:      HealthResponse;
+  latencyMs: number;
+}> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const t0 = performance.now();
-    const res = await fetch(`${server.url}/health`, { signal: controller.signal });
-    const latencyMs = Math.round(performance.now() - t0);
-    const body = await res.json() as { players?: number };
-    return {
-      info: server,
-      online: true,
-      players: typeof body.players === 'number' ? body.players : 0,
-      latencyMs,
-    };
-  } catch {
-    return { info: server, online: false, players: 0, latencyMs: 0 };
+    const res = await fetch(`${url.replace(/\/$/, '')}/health`, { signal: controller.signal });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const body = await res.json() as HealthResponse;
+    return { body, latencyMs: Math.round(performance.now() - t0) };
   } finally {
     clearTimeout(timer);
   }
 }
 
-// ─── Ping all servers in parallel ────────────────────────────────────────────
+export async function pingServer(server: ServerInfo): Promise<ServerStatus> {
+  try {
+    const { body, latencyMs } = await probeServer(server.url);
+    const serverVersion = typeof body.version === 'string' ? body.version : null;
+    const versionCompatible = serverVersion !== null
+      ? isMajorCompatible(GAME_VERSION, serverVersion)
+      // Old servers without a `version` field — treat as legacy/incompatible
+      // so users see why they can't connect.
+      : false;
+    return {
+      info: server,
+      online: true,
+      players: typeof body.players === 'number' ? body.players : 0,
+      latencyMs,
+      serverVersion,
+      versionCompatible,
+    };
+  } catch {
+    return {
+      info: server,
+      online: false,
+      players: 0,
+      latencyMs: 0,
+      serverVersion: null,
+      versionCompatible: false,
+    };
+  }
+}
 
 export async function pingAllServers(servers: ServerInfo[]): Promise<ServerStatus[]> {
   return Promise.all(servers.map(pingServer));

--- a/apps/client/src/ui/index.ts
+++ b/apps/client/src/ui/index.ts
@@ -1,9 +1,16 @@
-import { Direction } from '@bombermp/shared';
+import { Direction, GAME_VERSION, isMajorCompatible } from '@bombermp/shared';
 import type { RoomState, RoomPlayer, PublicRoomInfo } from '@bombermp/shared';
 import type { PlayerAppearance } from '../game/appearance.js';
 import { drawPlayerPreview } from '../game/renderer.js';
 import { iconPath } from '../assets/registry.js';
-import { fetchServerList, pingAllServers } from '../socket/servers.js';
+import {
+  fetchServerList,
+  pingAllServers,
+  probeServer,
+  addCustomServer,
+  removeCustomServer,
+  customSlugFromUrl,
+} from '../socket/servers.js';
 import type { ServerInfo, ServerStatus } from '../socket/servers.js';
 import { isCrazyGamesEnv, showInvitePopup } from '../crazygames/sdk.js';
 
@@ -65,6 +72,7 @@ export function showServerSelect(root: HTMLElement, options: ShowServerSelectOpt
 
   let statuses: ServerStatus[] = [];
   let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let mode: 'list' | 'add' = 'list';
 
   function cleanup(): void {
     if (pollTimer !== null) { clearInterval(pollTimer); pollTimer = null; }
@@ -77,6 +85,70 @@ export function showServerSelect(root: HTMLElement, options: ShowServerSelectOpt
     return 'bmp-server__latency--bad';
   }
 
+  function statusSubtitle(s: ServerStatus): { text: string; className: string } {
+    if (!s.online) return { text: 'Offline', className: '' };
+    if (!s.versionCompatible) {
+      const v = s.serverVersion ?? 'unknown';
+      return { text: `Version not supported (server v${v}, you v${GAME_VERSION})`, className: 'bmp-server__sub--warn' };
+    }
+    return {
+      text: `${s.players} player${s.players !== 1 ? 's' : ''} online`,
+      className: '',
+    };
+  }
+
+  function renderRow(s: ServerStatus): string {
+    const sub = statusSubtitle(s);
+    const customBadge = s.info.isCustom ? '<span class="bmp-server__custom-tag">custom</span>' : '';
+    const removeBtn = s.info.isCustom
+      ? `<button class="bmp-server__remove" data-remove-slug="${escHtml(s.info.slug)}" title="Remove server" aria-label="Remove server">\u00d7</button>`
+      : '';
+
+    if (!s.online) {
+      return `
+        <div class="bmp-server-row-wrap">
+          <button class="bmp-play-option bmp-server-row bmp-server-row--offline" disabled>
+            <div class="bmp-play-option__text">
+              <span class="bmp-play-option__title">${escHtml(s.info.name)} ${customBadge}</span>
+              <span class="bmp-play-option__sub">Offline</span>
+            </div>
+            <span class="bmp-server__badge bmp-server__latency--offline">--</span>
+          </button>
+          ${removeBtn}
+        </div>
+      `;
+    }
+
+    if (!s.versionCompatible) {
+      return `
+        <div class="bmp-server-row-wrap">
+          <button class="bmp-play-option bmp-server-row bmp-server-row--incompatible" disabled
+            title="${escHtml(sub.text)}">
+            <div class="bmp-play-option__text">
+              <span class="bmp-play-option__title">${escHtml(s.info.name)} ${customBadge}</span>
+              <span class="bmp-play-option__sub ${sub.className}">${escHtml(sub.text)}</span>
+            </div>
+            <span class="bmp-server__badge bmp-server__badge--warn">v${escHtml(s.serverVersion ?? '?')}</span>
+          </button>
+          ${removeBtn}
+        </div>
+      `;
+    }
+
+    return `
+      <div class="bmp-server-row-wrap">
+        <button class="bmp-play-option bmp-server-row" data-slug="${escHtml(s.info.slug)}">
+          <div class="bmp-play-option__text">
+            <span class="bmp-play-option__title">${escHtml(s.info.name)} ${customBadge}</span>
+            <span class="bmp-play-option__sub">${escHtml(sub.text)}</span>
+          </div>
+          <span class="bmp-server__badge ${latencyClass(s.latencyMs)}">${s.latencyMs}ms</span>
+        </button>
+        ${removeBtn}
+      </div>
+    `;
+  }
+
   function renderList(): void {
     const listEl = root.querySelector<HTMLDivElement>('#server-list');
     if (!listEl) return;
@@ -86,30 +158,9 @@ export function showServerSelect(root: HTMLElement, options: ShowServerSelectOpt
       return;
     }
 
-    listEl.innerHTML = statuses.map((s) => {
-      if (!s.online) {
-        return `
-          <button class="bmp-play-option bmp-server-row bmp-server-row--offline" disabled>
-            <div class="bmp-play-option__text">
-              <span class="bmp-play-option__title">${escHtml(s.info.name)}</span>
-              <span class="bmp-play-option__sub">Offline</span>
-            </div>
-            <span class="bmp-server__badge bmp-server__latency--offline">--</span>
-          </button>
-        `;
-      }
-      return `
-        <button class="bmp-play-option bmp-server-row" data-slug="${escHtml(s.info.slug)}">
-          <div class="bmp-play-option__text">
-            <span class="bmp-play-option__title">${escHtml(s.info.name)}</span>
-            <span class="bmp-play-option__sub">${s.players} player${s.players !== 1 ? 's' : ''} online</span>
-          </div>
-          <span class="bmp-server__badge ${latencyClass(s.latencyMs)}">${s.latencyMs}ms</span>
-        </button>
-      `;
-    }).join('');
+    listEl.innerHTML = statuses.map(renderRow).join('');
 
-    // Bind click handlers
+    // Connect handlers
     for (const btn of listEl.querySelectorAll<HTMLButtonElement>('.bmp-server-row[data-slug]')) {
       btn.addEventListener('click', () => {
         const slug = btn.dataset['slug']!;
@@ -120,31 +171,152 @@ export function showServerSelect(root: HTMLElement, options: ShowServerSelectOpt
         }
       });
     }
+
+    // Remove handlers
+    for (const btn of listEl.querySelectorAll<HTMLButtonElement>('[data-remove-slug]')) {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const slug = btn.dataset['removeSlug']!;
+        removeCustomServer(slug);
+        statuses = statuses.filter((s) => s.info.slug !== slug);
+        renderList();
+      });
+    }
   }
 
   async function refresh(): Promise<void> {
+    if (mode !== 'list') return;
     const servers = await fetchServerList();
     statuses = await pingAllServers(servers);
-    renderList();
+    if (mode === 'list') renderList();
   }
 
-  // Initial render
-  root.innerHTML = `
-    <div class="bmp-dec bmp-dec--circle-yellow" aria-hidden="true"></div>
-    <div class="bmp-dec bmp-dec--circle-pink"   aria-hidden="true"></div>
+  function renderListView(): void {
+    mode = 'list';
+    root.innerHTML = `
+      <div class="bmp-dec bmp-dec--circle-yellow" aria-hidden="true"></div>
+      <div class="bmp-dec bmp-dec--circle-pink"   aria-hidden="true"></div>
 
-    ${logoHtml()}
+      ${logoHtml()}
+      <div class="bmp-version-pill" title="Client version">v${escHtml(GAME_VERSION)}</div>
 
-    ${cardHtml({
-      headerClass: 'bmp-card__header--violet',
-      title: 'Select Server',
-      style: 'width:100%',
-      body: '<div id="server-list"><p class="bmp-server__loading">Checking servers\u2026</p></div>',
-    })}
-  `;
+      ${cardHtml({
+        headerClass: 'bmp-card__header--violet',
+        title: 'Select Server',
+        style: 'width:100%',
+        body: `
+          <div id="server-list"><p class="bmp-server__loading">Checking servers\u2026</p></div>
+          <div class="bmp-action-row" style="justify-content:flex-start">
+            <button class="bmp-btn bmp-btn--ghost bmp-btn--sm" id="add-server-btn">+ Add Custom Server</button>
+          </div>
+        `,
+      })}
+    `;
+    renderList();
+    root.querySelector<HTMLButtonElement>('#add-server-btn')!.addEventListener('click', () => {
+      cleanup();
+      renderAddView();
+    });
 
-  void refresh();
-  pollTimer = setInterval(() => { void refresh(); }, 10_000);
+    if (pollTimer !== null) clearInterval(pollTimer);
+    pollTimer = setInterval(() => { void refresh(); }, 10_000);
+    void refresh();
+  }
+
+  function renderAddView(): void {
+    mode = 'add';
+    root.innerHTML = `
+      ${logoHtml()}
+      <div class="bmp-version-pill" title="Client version">v${escHtml(GAME_VERSION)}</div>
+
+      ${cardHtml({
+        headerClass: 'bmp-card__header--violet',
+        title: 'Add Custom Server',
+        style: 'width:100%;max-width:420px',
+        body: `
+          <div class="bmp-field">
+            <label class="bmp-label" for="add-server-name">Display name</label>
+            <input class="bmp-input" id="add-server-name" type="text"
+              placeholder="My Server" maxlength="32" autocomplete="off" />
+          </div>
+          <div class="bmp-field">
+            <label class="bmp-label" for="add-server-url">Server URL</label>
+            <input class="bmp-input bmp-input--mono" id="add-server-url" type="url"
+              placeholder="https://my-bombermp.example.com" autocomplete="off" />
+          </div>
+          <p class="bmp-error" id="add-server-error" role="alert" aria-live="polite"></p>
+          <p class="bmp-server__loading bmp-hidden" id="add-server-status">Validating server\u2026</p>
+          <div class="bmp-action-row">
+            <button class="bmp-btn bmp-btn--danger bmp-btn--sm" id="add-server-cancel">\u2190 Cancel</button>
+            <button class="bmp-btn bmp-btn--secondary" id="add-server-submit">
+              Validate &amp; Add <span class="bmp-btn__arrow">\u2192</span>
+            </button>
+          </div>
+        `,
+      })}
+    `;
+
+    const nameEl   = root.querySelector<HTMLInputElement>('#add-server-name')!;
+    const urlEl    = root.querySelector<HTMLInputElement>('#add-server-url')!;
+    const errorEl  = root.querySelector<HTMLParagraphElement>('#add-server-error')!;
+    const statusEl = root.querySelector<HTMLParagraphElement>('#add-server-status')!;
+    const submit   = root.querySelector<HTMLButtonElement>('#add-server-submit')!;
+    const cancel   = root.querySelector<HTMLButtonElement>('#add-server-cancel')!;
+
+    nameEl.focus();
+
+    function setError(msg: string): void { errorEl.textContent = msg; }
+    function setBusy(busy: boolean): void {
+      submit.disabled = busy;
+      cancel.disabled = busy;
+      statusEl.classList.toggle('bmp-hidden', !busy);
+    }
+
+    cancel.addEventListener('click', () => renderListView());
+
+    async function attemptAdd(): Promise<void> {
+      setError('');
+      const name = nameEl.value.trim();
+      const url  = urlEl.value.trim().replace(/\/$/, '');
+      if (!name) { setError('Enter a name'); nameEl.focus(); return; }
+      if (!url)  { setError('Enter a URL');  urlEl.focus();  return; }
+      try {
+        // eslint-disable-next-line no-new
+        new URL(url);
+      } catch {
+        setError('URL is not valid'); urlEl.focus(); return;
+      }
+
+      setBusy(true);
+      try {
+        const { body } = await probeServer(url);
+        if (body.status !== 'ok') throw new Error('Server did not return status=ok');
+        const serverVersion = typeof body.version === 'string' ? body.version : null;
+        if (!serverVersion) {
+          setError('Server did not report a version (legacy/unsupported)');
+          setBusy(false);
+          return;
+        }
+        if (!isMajorCompatible(GAME_VERSION, serverVersion)) {
+          setError(`Version not supported: server is v${serverVersion}, you are v${GAME_VERSION}`);
+          setBusy(false);
+          return;
+        }
+        addCustomServer({ slug: customSlugFromUrl(url), name, url });
+        renderListView();
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : 'Could not reach server';
+        setError(`Could not reach server: ${msg}`);
+        setBusy(false);
+      }
+    }
+
+    submit.addEventListener('click', () => { void attemptAdd(); });
+    nameEl.addEventListener('keydown', (e) => { if (e.key === 'Enter') urlEl.focus(); });
+    urlEl.addEventListener('keydown',  (e) => { if (e.key === 'Enter') void attemptAdd(); });
+  }
+
+  renderListView();
 }
 
 // ─── HTML component helpers ───────────────────────────────────────────────────
@@ -1546,6 +1718,68 @@ function injectStyles(): void {
     .bmp-server-row--offline {
       opacity: 0.45;
       cursor: not-allowed !important;
+    }
+    .bmp-server-row--incompatible {
+      opacity: 0.7;
+      cursor: not-allowed !important;
+      border-color: #FBBF24 !important;
+    }
+    .bmp-server-row-wrap {
+      position: relative;
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+    .bmp-server-row-wrap > .bmp-play-option { flex: 1; }
+    .bmp-server__remove {
+      flex-shrink: 0;
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      border: 1.5px solid #CBD5E1;
+      background: #FFFFFF;
+      color: #94A3B8;
+      cursor: pointer;
+      font-size: 1rem;
+      line-height: 1;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      transition: all 0.15s;
+    }
+    .bmp-server__remove:hover {
+      background: #FEE2E2;
+      border-color: #DC2626;
+      color: #DC2626;
+    }
+    .bmp-server__custom-tag {
+      display: inline-block;
+      font-size: 0.6rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #6D28D9;
+      background: #EDE9FE;
+      border-radius: 99px;
+      padding: 0.05rem 0.4rem;
+      margin-left: 0.3rem;
+      vertical-align: middle;
+    }
+    .bmp-server__sub--warn { color: #92400E !important; font-weight: 600; }
+    .bmp-server__badge--warn { background: #FEF3C7; color: #92400E; }
+
+    .bmp-version-pill {
+      display: inline-block;
+      font-size: 0.7rem;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      color: #64748B;
+      background: #F1F5F9;
+      border: 1.5px solid #CBD5E1;
+      border-radius: 999px;
+      padding: 0.15rem 0.7rem;
+      margin-bottom: 0.5rem;
+      font-family: 'Outfit', monospace;
     }
     .bmp-server__badge {
       font-size: 0.75rem;

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@bombermp/server",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc --build",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -10,6 +10,7 @@ import type {
   ServerToClientEvents,
   SocketData,
 } from '@bombermp/shared';
+import { GAME_VERSION } from '@bombermp/shared';
 import { connectDB, disconnectDB } from './db/connection.js';
 import { registerHandlers } from './sockets/handlers.js';
 
@@ -43,7 +44,12 @@ const roomManager = registerHandlers(io);
 
 app.get('/health', (_req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
-  res.json({ status: 'ok', ts: Date.now(), players: roomManager.getTotalPlayerCount() });
+  res.json({
+    status: 'ok',
+    ts: Date.now(),
+    version: GAME_VERSION,
+    players: roomManager.getTotalPlayerCount(),
+  });
 });
 
 // ─── Start ────────────────────────────────────────────────────────────────────
@@ -56,7 +62,7 @@ async function start(): Promise<void> {
   }
 
   httpServer.listen(PORT, () => {
-    console.log(`[server] listening on http://localhost:${PORT}`);
+    console.log(`[server] listening on http://localhost:${PORT} (version ${GAME_VERSION})`);
   });
 }
 

--- a/apps/server/src/sockets/handlers.ts
+++ b/apps/server/src/sockets/handlers.ts
@@ -6,6 +6,7 @@ import type {
   InterServerEvents,
   SocketData,
 } from '@bombermp/shared';
+import { GAME_VERSION, isMajorCompatible, describeVersionMismatch } from '@bombermp/shared';
 import { RoomManager } from '../rooms/RoomManager.js';
 import { PlayerModel } from '../db/models/Player.js';
 
@@ -16,6 +17,17 @@ export function registerHandlers(io: IoServer): RoomManager {
   const roomManager = new RoomManager(io);
 
   io.on('connection', (socket: IoSocket) => {
+    // ── Validate client version (major must match) ────────────────────────────
+    const rawVersion = socket.handshake.auth['clientVersion'] as unknown;
+    const clientVersion = typeof rawVersion === 'string' ? rawVersion : '0.0.0';
+    if (!isMajorCompatible(clientVersion, GAME_VERSION)) {
+      const message = describeVersionMismatch(clientVersion, GAME_VERSION);
+      console.warn(`[socket] rejecting ${socket.id}: ${message}`);
+      socket.emit('error', { message });
+      socket.disconnect(true);
+      return;
+    }
+
     // ── Validate player identity ──────────────────────────────────────────────
     const rawId = socket.handshake.auth['playerId'] as unknown;
     const playerId = typeof rawId === 'string' && validateUUID(rawId) ? rawId : null;
@@ -29,8 +41,9 @@ export function registerHandlers(io: IoServer): RoomManager {
     socket.data.playerId = playerId;
     socket.data.roomId = null;
     socket.data.displayName = '';
+    socket.data.clientVersion = clientVersion;
 
-    console.log(`[socket] connected: ${socket.id} player=${playerId}`);
+    console.log(`[socket] connected: ${socket.id} player=${playerId} v=${clientVersion}`);
 
     // ── room:create ───────────────────────────────────────────────────────────
     socket.on('room:create', ({ displayName, isPublic }) => {

--- a/journal/prompts/15
+++ b/journal/prompts/15
@@ -1,0 +1,23 @@
+feat: ability to register own server in server selection menu
+it will be added in local stroage of that perticular user's browser
+
+do changes in this branch: feat/register-own-server
+
+but for that we need to validate that server have valid version of api
+and also we need to versoning in the system
+
+so implementation of that will also be needed
+lets keep the version in semver format:
+major.minor.patch
+
+we will have a utility to update the version of game and api should also expose the version of game
+client build will also have a copy of version in it
+
+client will validate the version of api while connecting to the server
+
+older will not connect to newer version of server (only for major version)
+newer client will not connect to older version of server (only for major version)
+
+giving the client: "version not supported" message
+
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bombermp",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "private": true,
   "packageManager": "pnpm@10.28.2",
   "scripts": {
@@ -8,7 +8,8 @@
     "build": "pnpm --filter @bombermp/shared build && pnpm --filter @bombermp/server build && pnpm --filter @bombermp/client build",
     "typecheck": "pnpm --filter @bombermp/shared typecheck && pnpm --filter @bombermp/server typecheck && pnpm --filter @bombermp/client typecheck",
     "lint": "eslint . --ext .ts,.tsx",
-    "test": "echo \"No tests yet\""
+    "test": "echo \"No tests yet\"",
+    "version:bump": "node scripts/bump-version.mjs"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.18.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bombermp/shared",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "exports": {
@@ -9,7 +9,9 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,3 +2,4 @@ export * from './types/index.js';
 export * from './constants/game.js';
 export * from './utils/grid.js';
 export * from './utils/explosions.js';
+export * from './version.js';

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -189,4 +189,5 @@ export interface SocketData {
   playerId: string;
   displayName: string;
   roomId: string | null;
+  clientVersion: string;
 }

--- a/packages/shared/src/version.ts
+++ b/packages/shared/src/version.ts
@@ -1,0 +1,60 @@
+// ─── Game Version (semver: major.minor.patch) ────────────────────────────────
+//
+// Single source of truth for the BomberMP API/protocol version. The build
+// pipeline keeps this in sync with the workspace package.json files via
+// `scripts/bump-version.mjs`. Bumping rules:
+//
+//   - **major** → breaking protocol change (event payload shape, auth flow,
+//     game-state format). Major-version mismatch prevents client/server from
+//     connecting (`version not supported`).
+//   - **minor** → backwards-compatible additions (new optional fields, new
+//     events the old client can ignore).
+//   - **patch** → bug fixes, no protocol surface change.
+//
+// Both server and client compare their *major* component on connect; minor
+// and patch can drift freely.
+
+export const GAME_VERSION = '1.0.1';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+export interface SemVer {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+/** Parse a `M.m.p` string. Returns `null` if invalid. */
+export function parseSemVer(input: string): SemVer | null {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(input.trim());
+  if (!m) return null;
+  return {
+    major: Number(m[1]),
+    minor: Number(m[2]),
+    patch: Number(m[3]),
+  };
+}
+
+/** True iff both versions parse and share the same major. */
+export function isMajorCompatible(a: string, b: string): boolean {
+  const va = parseSemVer(a);
+  const vb = parseSemVer(b);
+  if (!va || !vb) return false;
+  return va.major === vb.major;
+}
+
+/** Human-readable reason for a version mismatch ("client too old / new"). */
+export function describeVersionMismatch(clientVersion: string, serverVersion: string): string {
+  const c = parseSemVer(clientVersion);
+  const s = parseSemVer(serverVersion);
+  if (!c || !s) {
+    return `Version not supported (client ${clientVersion}, server ${serverVersion})`;
+  }
+  if (c.major < s.major) {
+    return `Version not supported: client ${clientVersion} is older than server ${serverVersion}. Please refresh.`;
+  }
+  if (c.major > s.major) {
+    return `Version not supported: client ${clientVersion} is newer than server ${serverVersion}.`;
+  }
+  return `Version mismatch (client ${clientVersion}, server ${serverVersion})`;
+}

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// Bumps the BomberMP game version across the monorepo.
+//
+//   node scripts/bump-version.mjs <major|minor|patch>
+//   node scripts/bump-version.mjs <X.Y.Z>          # set explicitly
+//
+// Updates:
+//   - root package.json
+//   - apps/server, apps/client, packages/shared package.json
+//   - packages/shared/src/version.ts (GAME_VERSION constant)
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+const PACKAGE_JSONS = [
+  'package.json',
+  'apps/server/package.json',
+  'apps/client/package.json',
+  'packages/shared/package.json',
+];
+
+const VERSION_TS = 'packages/shared/src/version.ts';
+
+function readJson(rel) {
+  return JSON.parse(readFileSync(resolve(ROOT, rel), 'utf8'));
+}
+
+function writeJson(rel, obj) {
+  writeFileSync(resolve(ROOT, rel), JSON.stringify(obj, null, 2) + '\n');
+}
+
+function parse(v) {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(String(v).trim());
+  if (!m) throw new Error(`Not a valid semver: ${v}`);
+  return { major: +m[1], minor: +m[2], patch: +m[3] };
+}
+
+function fmt({ major, minor, patch }) {
+  return `${major}.${minor}.${patch}`;
+}
+
+function bump(current, kind) {
+  const v = parse(current);
+  switch (kind) {
+    case 'major': return fmt({ major: v.major + 1, minor: 0, patch: 0 });
+    case 'minor': return fmt({ ...v, minor: v.minor + 1, patch: 0 });
+    case 'patch': return fmt({ ...v, patch: v.patch + 1 });
+    default: {
+      // Treat as explicit version
+      const explicit = parse(kind);
+      return fmt(explicit);
+    }
+  }
+}
+
+function main() {
+  const arg = process.argv[2];
+  if (!arg) {
+    console.error('Usage: node scripts/bump-version.mjs <major|minor|patch|X.Y.Z>');
+    process.exit(1);
+  }
+
+  const root = readJson('package.json');
+  const current = root.version;
+  const next = bump(current, arg);
+
+  console.log(`Bumping version: ${current} → ${next}`);
+
+  // Update all package.json files
+  for (const rel of PACKAGE_JSONS) {
+    const pkg = readJson(rel);
+    pkg.version = next;
+    writeJson(rel, pkg);
+    console.log(`  updated ${rel}`);
+  }
+
+  // Update version.ts
+  const versionTsPath = resolve(ROOT, VERSION_TS);
+  const versionTs = readFileSync(versionTsPath, 'utf8');
+  const updated = versionTs.replace(
+    /export const GAME_VERSION = '[^']*';/,
+    `export const GAME_VERSION = '${next}';`,
+  );
+  if (updated === versionTs) {
+    console.error(`  WARNING: GAME_VERSION not found in ${VERSION_TS}`);
+  } else {
+    writeFileSync(versionTsPath, updated);
+    console.log(`  updated ${VERSION_TS}`);
+  }
+
+  console.log(`\nDone. New version: ${next}`);
+}
+
+main();


### PR DESCRIPTION
The server-select screen now lets users register their own servers (name
+ URL); entries live in localStorage and are validated by probing /health and checking major-version compatibility before being saved. A scripts/bump-version.mjs utility keeps every workspace package.json and the GAME_VERSION constant in lockstep.

Adds a single source of truth for the game version (semver, exposed via @bombermp/shared as GAME_VERSION) and uses it to gate connections: the server returns its version on /health and rejects socket handshakes from clients with a mismatched major version, surfacing a "version not supported" error. The client bakes its version into the build, sends it in the handshake auth payload, and probes /health before connecting so incompatible servers are flagged in the picker rather than failing mid-connect.